### PR TITLE
Fix workflow not respecting chosen branch

### DIFF
--- a/.github/workflows/Build Kernel OnePlus.yml
+++ b/.github/workflows/Build Kernel OnePlus.yml
@@ -724,14 +724,16 @@ jobs:
         id: manager
         run: |
           MANAGER_SOURCE="${{ github.event.inputs.MANAGER_SOURCE }}"
-
+          KSU_META="${{ github.event.inputs.KSU_META }}"
+          
+          BRANCH="${KSU_META%%/*}"
+          BRANCH="${BRANCH:-main}"
+          
           case "$MANAGER_SOURCE" in
             MD3_SPOOF)
-              BRANCH="main"
               ARTIFACT="Spoofed-Manager-release"
               ;;
             MD3|*)
-              BRANCH="main"
               ARTIFACT="Manager-release"
               ;;
           esac


### PR DESCRIPTION
- changes "main" from being hardcoded as the branch name (under MD3/MD3 spoof logic) to actually reading the branch name you type before the slash in the workflow
    - for some reason, the logic for building the kernel itself was defined below separately (which I left intact), so it was being built properly, but it was not keeping track of the correct branch internally (still showing "main") and causing it to download the manager CI from the wrong branch (e.g., downloading the latest CI from "main" branch even though you typed "dev/Numbersf/" in the workflow)... this would obviously cause the root to not even work since the build from the kernel would mismatch with the manager... this is fixed now though

side bug: there's a current bug (cosmetic only) where the the build number, which uses the number of commits (which is 4339 as of rn) to generate the file name, so it gives a build 30700 + 4339 =35,039 35039, but the correct CI build, downloaded from the latest CI for dev branch, is 35068, verifiable here https://github.com/ReSukiSU/ReSukiSU/actions/runs/28744188508. note that it worked fine with "main" (default) at 35,004.

<img width="456" height="268" alt="image" src="https://github.com/user-attachments/assets/1337a82d-6d35-4aa4-973d-4f0e589a433d" />

as you can see, it DOES download the correct latest CI (evidenced by the 35068), but internally just names the containing zip file wrong. as far as I can tell this is cosmetic only, so not really important, but just a little annoying.